### PR TITLE
128/256K devices need 24-bits for address pointer

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ from binaryninja import (
 
 class AVR(binaryninja.Architecture):
     name = 'AVR'
-    address_size = 2
+    address_size = 3
     default_int_size = 1
     # Instructions can only be 4 bytes in length MAX. However we need to have
     # the next instruction as well for some lifting reason, this is why we chose

--- a/instructions.py
+++ b/instructions.py
@@ -542,7 +542,7 @@ class Instruction_BR_Abstract(Instruction):
         )
 
         il.mark_label(t)
-        il.append(il.jump(il.const(2, rel_addr)))
+        il.append(il.jump(il.const(3, rel_addr)))
         il.mark_label(f)
 
 
@@ -1059,7 +1059,7 @@ class Instruction_CPSE(Instruction):
         il.append(
             il.jump(
                 il.const(
-                    2,
+                    3,
                     self._addr + 2 + next_len
                 )
             )
@@ -2775,7 +2775,7 @@ class Instruction_RJMP(Instruction):
 
         il.append(
             il.jump(
-                il.const(2, taddr)
+                il.const(3, taddr)
             )
         )
 
@@ -2990,7 +2990,7 @@ class Instruction_SkipInstruction_Abstract(Instruction):
         )
 
         il.mark_label(t)
-        il.append(il.jump(il.const(2, self._addr + 4)))
+        il.append(il.jump(il.const(3, self._addr + 4)))
         il.mark_label(f)
 
 

--- a/operand.py
+++ b/operand.py
@@ -105,7 +105,8 @@ class OperandImm(Operand):
 
 
 class OperandDirectAddress(OperandImm):
-    pass
+    def llil_read(self, il):
+        return il.const(3, self.immediate_value)
 
 
 class OperandImmediate(OperandImm):
@@ -113,4 +114,5 @@ class OperandImmediate(OperandImm):
 
 
 class OperandRelativeAddress(OperandImm):
-    pass
+    def llil_read(self, il):
+        return il.const(3, self.immediate_value)


### PR DESCRIPTION
The address pointer on xmega128/256 is 24 bit. This updates the size so BN will correctly resolve/display the jumps.